### PR TITLE
Fixed error in updateSession

### DIFF
--- a/components/WebUser.php
+++ b/components/WebUser.php
@@ -48,16 +48,19 @@ class WebUser extends CWebUser
 
     public function updateSession() {
         $user = Yii::app()->getModule('user')->user($this->id);
-        $this->name = $user->username;
-        $userAttributes = CMap::mergeArray(array(
-                                                'email'=>$user->email,
-                                                'username'=>$user->username,
-                                                'create_at'=>$user->create_at,
-                                                'lastvisit_at'=>$user->lastvisit_at,
-                                           ),$user->profile->getAttributes());
-        foreach ($userAttributes as $attrName=>$attrValue) {
-            $this->setState($attrName,$attrValue);
+        if ($user!==false){
+	        $this->name = $user->username;
+	        $userAttributes = CMap::mergeArray(array(
+	                                                'email'=>$user->email,
+	                                                'username'=>$user->username,
+	                                                'create_at'=>$user->create_at,
+	                                                'lastvisit_at'=>$user->lastvisit_at,
+	                                           ),$user->profile->getAttributes());
+	        foreach ($userAttributes as $attrName=>$attrValue) {
+	            $this->setState($attrName,$attrValue);
+	        }
         }
+        
     }
 
     public function model($id=0) {


### PR DESCRIPTION
After open the activation or change password link the program crashes because is impossible to retrieve the user model from updateSession method if the user isn't logged.
