### PR TITLE
Fixed issue with duplicate 'id' fields in Profiles and Users model.

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -163,7 +163,7 @@ class User extends CActiveRecord
 
         $criteria=new CDbCriteria;
         
-        $criteria->compare('id',$this->id);
+		  $criteria->compare(  $this->getTableAlias().'.id',$this->id);
         $criteria->compare('username',$this->username,true);
         $criteria->compare('password',$this->password);
         $criteria->compare('email',$this->email,true);


### PR DESCRIPTION
Just explicitly add table alias for SQL table
