### PR TITLE
Removed assumption that Pk is called 'id'

### DIFF
--- a/components/UWdropDownDep.php
+++ b/components/UWdropDownDep.php
@@ -66,7 +66,7 @@ class UWdropDownDep {
 		}
 		
 		if ($m)
-			return (($this->params['optionName'])?$m->getAttribute($this->params['optionName']):$m->id);
+			return (($this->params['optionName'])?$m->getAttribute($this->params['optionName']):$m->getAttribute($m->tableSchema->primaryKey));
 		else
 			return $this->params['emptyField'];
 		
@@ -84,7 +84,8 @@ class UWdropDownDep {
 		
 		$models = CActiveRecord::model($this->params['modelName'])->findAll();
 		foreach ($models as $m)
-			$list[$m->id] = (($this->params['optionName'])?$m->getAttribute($this->params['optionName']):$m->id);
+			$list[$m->getAttribute($m->tableSchema->primaryKey)] = 
+                                (($this->params['optionName'])?$m->getAttribute($this->params['optionName']):$m->getAttribute($m->tableSchema->primaryKey));
 		return CHtml::activeDropDownList($model,$field->varname,$list,$htmlOptions=array(
 				'ajax'=>array(
 						'type'=>'POST',


### PR DESCRIPTION
Hi mishamx,
First of all thank you for this plugin - it's proved very helpful in many of my projects. 

In the most recent one I used UWdropDownDep class and I run into an issue where in the class it would be assumed that my Pk is called 'id'. The convention I follow states that all column names start with a capital letter, so in my case it was 'Id' and the code would break. 

I've updated the logic to pull the actual name of the Pk using pure Yii. Hopefully you'll agree that this is more elegant solution. 

On a final note, this is my first ever pull request, so if I'm missing anything from it let me know. 

Cheers,
Marcin
