### PR TITLE
Update user.php - italian translation

### DIFF
--- a/messages/it/user.php
+++ b/messages/it/user.php
@@ -5,7 +5,7 @@
  */
 return array(
     'Registration' => 'Registrazione',
-    'Register' => 'Registro',
+    'Register' => 'Registrati',
     'Login' => 'Login',
     'Logout' => 'Logout',
     'username' => "Username (Nome Utente)",


### PR DESCRIPTION
The translation of "Register" in italian is wrong ("Registro" means something completely different). Fixed with "Registrati".
