### PR TITLE
fix php 5.6 constrains due to incompatible context

### DIFF
--- a/components/UWdropDownDep.php
+++ b/components/UWdropDownDep.php
@@ -89,7 +89,7 @@ class UWdropDownDep {
 		return CHtml::activeDropDownList($model,$field->varname,$list,$htmlOptions=array(
 				'ajax'=>array(
 						'type'=>'POST',
-						'url'=>CController::createUrl('/user/profileField/getDroDownDepValues'),
+						'url'=>Yii::app()->controller->createUrl('/user/profileField/getDroDownDepValues'),
 						'data'=>array('model'=>$this->params['modelDestName'], 'field_dest'=>$this->params['destField'], 'varname'=>$field->varname, $field->varname=>'js:this.value', 'optionDestName'=>$this->params['optionDestName']),
 						'success'=>'function(data){
         						$("#ajax_loader").hide();


### PR DESCRIPTION
"Non-static method CController::createUrl() should not be called statically, assuming $this from incompatible context"